### PR TITLE
Fix npm peer dependency error in CI

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -13,7 +13,7 @@ jobs:
           persist-credentials: false
       - name: Install and Build
         run: | # Install npm packages and build the Storybook files
-          npm install
+          npm install --legacy-peer-deps
           npm run build-storybook
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@3.6.2


### PR DESCRIPTION
Add --legacy-peer-deps flag to npm install to resolve peer dependency conflicts with the 'three' package from Storybook addons.

https://claude.ai/code/session_01FfhbMSwpEbYCKbngfuQpVy